### PR TITLE
Issue #18: add governance onboarding baseline

### DIFF
--- a/.context-engineering/governance.yml
+++ b/.context-engineering/governance.yml
@@ -1,0 +1,20 @@
+schema_version: "1.0"
+repository: "Josh-Phillips-LLC/JoshGPT-MCP"
+
+governance:
+  owner_system: "Context-Engineering"
+  owner_repo: "Josh-Phillips-LLC/Context-Engineering"
+  state: "transition"
+  registry_ref: "00-os/governed-repos.yml"
+  policy_ref: "governance.md#repository-governance-adoption-model-ownership-states"
+
+controls:
+  profile: "transition"
+  required_reviews:
+    - "Compliance Officer"
+
+evidence:
+  adoption_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/18"
+  rollout_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/18"
+
+last_reviewed_utc: "2026-02-25T00:00:00Z"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# Summary
+- 
+
+# Issue
+- Linked issue (must close):
+- Closes #
+
+# Machine-Readable Metadata (Required)
+Primary-Role:
+Reviewed-By-Role:
+Executive-Sponsor-Approval:
+
+# Role Attribution
+- [ ] At least one `role:*` label applied
+- [ ] Exactly one `status:*` label applied

--- a/.github/workflows/governance-pr-gates.yml
+++ b/.github/workflows/governance-pr-gates.yml
@@ -1,0 +1,81 @@
+name: governance-pr-gates
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  governance-pr-gates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR metadata and labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+            const labels = (pr.labels || []).map((label) => label.name || "");
+            const errors = [];
+
+            const requiredKeys = [
+              "Primary-Role:",
+              "Reviewed-By-Role:",
+              "Executive-Sponsor-Approval:",
+            ];
+
+            for (const key of requiredKeys) {
+              if (!body.includes(key)) {
+                errors.push(`Missing required PR metadata key: ${key}`);
+              }
+            }
+
+            function extractValue(key) {
+              const line = body
+                .split(/\r?\n/)
+                .find((entry) => entry.trim().startsWith(key));
+              if (!line) return "";
+              return line.slice(line.indexOf(":") + 1).trim();
+            }
+
+            const primaryRole = extractValue("Primary-Role:");
+            const reviewedByRole = extractValue("Reviewed-By-Role:");
+            const execApproval = extractValue("Executive-Sponsor-Approval:");
+
+            const allowedPrimaryRoles = [
+              "Executive Sponsor",
+              "AI Governance Manager",
+              "Compliance Officer",
+              "Business Analyst",
+              "Implementation Specialist",
+              "Systems Architect",
+            ];
+            const allowedReviewedByRoles = ["Compliance Officer", "Executive Sponsor", "N/A"];
+            const allowedExecApproval = ["Required", "Not-Required", "Provided"];
+
+            if (primaryRole && !allowedPrimaryRoles.includes(primaryRole)) {
+              errors.push(`Invalid Primary-Role value: \"${primaryRole}\"`);
+            }
+            if (reviewedByRole && !allowedReviewedByRoles.includes(reviewedByRole)) {
+              errors.push(`Invalid Reviewed-By-Role value: \"${reviewedByRole}\"`);
+            }
+            if (execApproval && !allowedExecApproval.includes(execApproval)) {
+              errors.push(`Invalid Executive-Sponsor-Approval value: \"${execApproval}\"`);
+            }
+
+            const roleLabels = labels.filter((name) => name.startsWith("role:"));
+            const statusLabels = labels.filter((name) => name.startsWith("status:"));
+
+            if (roleLabels.length < 1) {
+              errors.push("Missing role label: add at least one label with prefix role:");
+            }
+            if (statusLabels.length !== 1) {
+              errors.push(`Invalid status labels: expected exactly 1 label with prefix status:, found ${statusLabels.length}`);
+            }
+
+            if (errors.length > 0) {
+              core.setFailed(errors.join("\n"));
+            }


### PR DESCRIPTION
## Summary
- add `.context-engineering/governance.yml` governance marker for `transition` state onboarding
- add `.github/workflows/governance-pr-gates.yml` to enforce PR metadata + label gates
- add `.github/pull_request_template.md` with required machine-readable metadata keys

## Machine-Readable Metadata (Required)
Primary-Role: Systems Architect
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Not-Required

Closes Josh-Phillips-LLC/Context-Engineering#18
